### PR TITLE
feature/provide-context: providing context into callbacks and each callback should be able to refer the modal

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -3,49 +3,52 @@
  * author: João Pereira
  * website: http://www.joaopereira.pt
  * email: joaopereirawd@gmail.com
- * Licensed MIT 
+ * Licensed MIT
 =========================================*/
 
 (function ($) {
- 
+
     $.fn.animatedModal = function(options) {
-        var modal = $(this);
-        
+        var modal = $(this),
+            currentContext = this;
+
         //Defaults
         var settings = $.extend({
-            modalTarget:'animatedModal', 
-            position:'fixed', 
-            width:'100%', 
-            height:'100%', 
-            top:'0px', 
-            left:'0px', 
-            zIndexIn: '9999',  
-            zIndexOut: '-9999',  
-            color: '#39BEB9', 
-            opacityIn:'1',  
-            opacityOut:'0', 
+            modalTarget:'animatedModal',
+            position:'fixed',
+            width:'100%',
+            height:'100%',
+            top:'0px',
+            left:'0px',
+            zIndexIn: '9999',
+            zIndexOut: '-9999',
+            color: '#39BEB9',
+            opacityIn:'1',
+            opacityOut:'0',
             animatedIn:'zoomIn',
             animatedOut:'zoomOut',
-            animationDuration:'.6s', 
-            overflow:'auto', 
+            animationDuration:'.6s',
+            overflow:'auto',
             // Callbacks
-            beforeOpen: function() {},           
-            afterOpen: function() {}, 
-            beforeClose: function() {}, 
+            beforeOpen: function() {},
+            afterOpen: function() {},
+            beforeClose: function() {},
             afterClose: function() {}
- 
-            
 
         }, options);
-        
+
         var closeBt = $('.close-'+settings.modalTarget);
 
-        //console.log(closeBt)
+        ['beforeOpen', 'afterOpen', 'beforeClose', 'afterClose'].forEach(function(key) {
+          if (key in settings) {
+            settings[key] = settings[key].bind(this);
+          }
+        }, this);
 
         var href = $(modal).attr('href'),
             id = $('body').find('#'+settings.modalTarget),
             idConc = '#'+id.attr('id');
-            //console.log(idConc);
+
             // Default Classes
             id.addClass('animated');
             id.addClass(settings.modalTarget+'-off');
@@ -61,15 +64,12 @@
             'overflow-y':settings.overflow,
             'z-index':settings.zIndexOut,
             'opacity':settings.opacityOut,
-            '-webkit-animation-duration':settings.animationDuration,
-            '-moz-animation-duration':settings.animationDuration,
-            '-ms-animation-duration':settings.animationDuration,
-            'animation-duration':settings.animationDuration
+            '-webkit-animation-duration':settings.animationDuration
         };
         //Apply stles
         id.css(initStyles);
 
-        modal.click(function(event) {       
+        modal.click(function(event) {
             event.preventDefault();
             $('body, html').css({'overflow':'hidden'});
             if (href == idConc) {
@@ -77,15 +77,15 @@
                     id.removeClass(settings.animatedOut);
                     id.removeClass(settings.modalTarget+'-off');
                     id.addClass(settings.modalTarget+'-on');
-                } 
+                }
 
                  if (id.hasClass(settings.modalTarget+'-on')) {
-                    settings.beforeOpen();
+                    settings.beforeOpen(id);
                     id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
-                    id.addClass(settings.animatedIn);  
+                    id.addClass(settings.animatedIn);
                     id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
-                };  
-            } 
+                };
+            }
         });
 
 
@@ -94,11 +94,11 @@
             event.preventDefault();
             $('body, html').css({'overflow':'auto'});
 
-            settings.beforeClose(); //beforeClose
+            settings.beforeClose(id); //beforeClose
             if (id.hasClass(settings.modalTarget+'-on')) {
                 id.removeClass(settings.modalTarget+'-on');
                 id.addClass(settings.modalTarget+'-off');
-            } 
+            }
 
             if (id.hasClass(settings.modalTarget+'-off')) {
                 id.removeClass(settings.animatedIn);
@@ -108,13 +108,13 @@
 
         });
 
-        function afterClose () {       
+        function afterClose () {
             id.css({'z-index':settings.zIndexOut});
-            settings.afterClose(); //afterClose
+            settings.afterClose(id); //afterClose
         }
 
-        function afterOpen () {       
-            settings.afterOpen(); //afterOpen
+        function afterOpen () {
+            settings.afterOpen(id); //afterOpen
         }
 
     }; // End animatedModal.js
@@ -123,4 +123,4 @@
 
 
 
-        
+

--- a/demo/demos.html
+++ b/demo/demos.html
@@ -23,15 +23,15 @@
             <li><a id="demo01" href="#animatedModal">DEMO01</a></li>
             <li><a id="demo02" href="#modal-02">DEMO02</a></li>
         </ul>
-      
-      
+
+
         <!--DEMO01-->
         <div id="animatedModal">
             <!--THIS IS IMPORTANT! to close the modal, the class name has to match the name given on the ID -->
-            <div  id="btn-close-modal" class="close-animatedModal"> 
+            <div  id="btn-close-modal" class="close-animatedModal">
                 CLOSE MODAL
             </div>
-                
+
             <div class="modal-content">
                 <!--Your modal content goes here-->
             </div>
@@ -40,10 +40,10 @@
         <!--DEMO02-->
         <div id="modal-02">
             <!--"THIS IS IMPORTANT! to close the modal, the class name has to match the name given on the ID-->
-            <div  id="btn-close-modal" class="close-modal-02"> 
+            <div  id="btn-close-modal" class="close-modal-02">
                 CLOSE MODAL
             </div>
-            
+
             <div class="modal-content">
                 <!--Your modal content goes here-->
             </div>
@@ -51,11 +51,24 @@
 
 
         <script src="js/jquery.min.js"></script>
-        <script src="js/animatedModal.min.js"></script>
+        <script src="js/animatedModal.js"></script>
         <script>
 
             //demo 01
-            $("#demo01").animatedModal();
+            $("#demo01").animatedModal({
+                beforeOpen: function() {
+                    console.log(this, arguments);
+                },
+                afterOpen: function() {
+                    console.log(this, arguments);
+                },
+                beforeClose: function() {
+                    console.log(this, arguments);
+                },
+                afterClose: function() {
+                    console.log(this, arguments);
+                }
+            });
 
             //demo 02
             $("#demo02").animatedModal({
@@ -66,13 +79,13 @@
                 // Callbacks
                 beforeOpen: function() {
                     console.log("The animation was called");
-                },           
+                },
                 afterOpen: function() {
                     console.log("The animation is completed");
-                }, 
+                },
                 beforeClose: function() {
                     console.log("The animation was called");
-                }, 
+                },
                 afterClose: function() {
                     console.log("The animation is completed");
                 }

--- a/demo/js/animatedModal.js
+++ b/demo/js/animatedModal.js
@@ -3,49 +3,52 @@
  * author: João Pereira
  * website: http://www.joaopereira.pt
  * email: joaopereirawd@gmail.com
- * Licensed MIT 
+ * Licensed MIT
 =========================================*/
 
 (function ($) {
- 
+
     $.fn.animatedModal = function(options) {
-        var modal = $(this);
-        
+        var modal = $(this),
+            currentContext = this;
+
         //Defaults
         var settings = $.extend({
-            modalTarget:'animatedModal', 
-            position:'fixed', 
-            width:'100%', 
-            height:'100%', 
-            top:'0px', 
-            left:'0px', 
-            zIndexIn: '9999',  
-            zIndexOut: '-9999',  
-            color: '#39BEB9', 
-            opacityIn:'1',  
-            opacityOut:'0', 
+            modalTarget:'animatedModal',
+            position:'fixed',
+            width:'100%',
+            height:'100%',
+            top:'0px',
+            left:'0px',
+            zIndexIn: '9999',
+            zIndexOut: '-9999',
+            color: '#39BEB9',
+            opacityIn:'1',
+            opacityOut:'0',
             animatedIn:'zoomIn',
             animatedOut:'zoomOut',
-            animationDuration:'.6s', 
-            overflow:'auto', 
+            animationDuration:'.6s',
+            overflow:'auto',
             // Callbacks
-            beforeOpen: function() {},           
-            afterOpen: function() {}, 
-            beforeClose: function() {}, 
+            beforeOpen: function() {},
+            afterOpen: function() {},
+            beforeClose: function() {},
             afterClose: function() {}
- 
-            
 
         }, options);
-        
+
         var closeBt = $('.close-'+settings.modalTarget);
 
-        //console.log(closeBt)
+        ['beforeOpen', 'afterOpen', 'beforeClose', 'afterClose'].forEach(function(key) {
+          if (key in settings) {
+            settings[key] = settings[key].bind(this);
+          }
+        }, this);
 
         var href = $(modal).attr('href'),
             id = $('body').find('#'+settings.modalTarget),
             idConc = '#'+id.attr('id');
-            //console.log(idConc);
+
             // Default Classes
             id.addClass('animated');
             id.addClass(settings.modalTarget+'-off');
@@ -66,7 +69,7 @@
         //Apply stles
         id.css(initStyles);
 
-        modal.click(function(event) {       
+        modal.click(function(event) {
             event.preventDefault();
             $('body, html').css({'overflow':'hidden'});
             if (href == idConc) {
@@ -74,15 +77,15 @@
                     id.removeClass(settings.animatedOut);
                     id.removeClass(settings.modalTarget+'-off');
                     id.addClass(settings.modalTarget+'-on');
-                } 
+                }
 
                  if (id.hasClass(settings.modalTarget+'-on')) {
-                    settings.beforeOpen();
+                    settings.beforeOpen(id);
                     id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
-                    id.addClass(settings.animatedIn);  
+                    id.addClass(settings.animatedIn);
                     id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
-                };  
-            } 
+                };
+            }
         });
 
 
@@ -91,11 +94,11 @@
             event.preventDefault();
             $('body, html').css({'overflow':'auto'});
 
-            settings.beforeClose(); //beforeClose
+            settings.beforeClose(id); //beforeClose
             if (id.hasClass(settings.modalTarget+'-on')) {
                 id.removeClass(settings.modalTarget+'-on');
                 id.addClass(settings.modalTarget+'-off');
-            } 
+            }
 
             if (id.hasClass(settings.modalTarget+'-off')) {
                 id.removeClass(settings.animatedIn);
@@ -105,13 +108,13 @@
 
         });
 
-        function afterClose () {       
+        function afterClose () {
             id.css({'z-index':settings.zIndexOut});
-            settings.afterClose(); //afterClose
+            settings.afterClose(id); //afterClose
         }
 
-        function afterOpen () {       
-            settings.afterOpen(); //afterOpen
+        function afterOpen () {
+            settings.afterOpen(id); //afterOpen
         }
 
     }; // End animatedModal.js
@@ -120,4 +123,4 @@
 
 
 
-        
+


### PR DESCRIPTION
### Note

This is a conceptual proposal and is open to improvements!
I will minify/compile the js once the concept is approved
### Description

Context should be provided into beforeOpen,beforeClose,afterOpen,afterClose and passed the modal as an argument
### Example

**Before**:

``` js
$("#demo01").animatedModal({
    beforeOpen: function() {
        // a modal instance is not accessable here
        console.log(this); // this refers to the options object. not useful
    }
});
```

**After**:

``` js
$("#demo01").animatedModal({
    beforeOpen: function(modal) {
        console.log(this); // this is bound to the caller element => $('#demo01')
        console.log(modal); // the modal instance
    },
});
```
