### PR TITLE
feature/12: Exposing a service with accessable methods to the modal

### DIFF
--- a/demo/js/animatedModal.js
+++ b/demo/js/animatedModal.js
@@ -32,10 +32,8 @@
             beforeOpen: function() {},           
             afterOpen: function() {}, 
             beforeClose: function() {}, 
-            afterClose: function() {}
- 
-            
-
+            afterClose: function() {},
+            override: false
         }, options);
         
         var closeBt = $('.close-'+settings.modalTarget);
@@ -66,26 +64,12 @@
         //Apply stles
         id.css(initStyles);
 
-        modal.click(function(event) {       
-            event.preventDefault();
-            $('body, html').css({'overflow':'hidden'});
-            if (href == idConc) {
-                if (id.hasClass(settings.modalTarget+'-off')) {
-                    id.removeClass(settings.animatedOut);
-                    id.removeClass(settings.modalTarget+'-off');
-                    id.addClass(settings.modalTarget+'-on');
-                } 
-
-                 if (id.hasClass(settings.modalTarget+'-on')) {
-                    settings.beforeOpen();
-                    id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
-                    id.addClass(settings.animatedIn);  
-                    id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
-                };  
-            } 
-        });
-
-
+        if (!settings.override) {
+            modal.click(function(event) {
+                event.preventDefault();
+                open();
+            });
+        }
 
         closeBt.click(function(event) {
             event.preventDefault();
@@ -114,6 +98,27 @@
             settings.afterOpen(); //afterOpen
         }
 
+        function open() {
+            $('body, html').css({'overflow':'hidden'});
+            if (href == idConc) {
+                if (id.hasClass(settings.modalTarget+'-off')) {
+                    id.removeClass(settings.animatedOut);
+                    id.removeClass(settings.modalTarget+'-off');
+                    id.addClass(settings.modalTarget+'-on');
+                }
+
+                if (id.hasClass(settings.modalTarget+'-on')) {
+                    settings.beforeOpen();
+                    id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
+                    id.addClass(settings.animatedIn);
+                    id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
+                };
+            }
+        }
+
+        return {
+            open: open
+        };
     }; // End animatedModal.js
 
 }(jQuery));


### PR DESCRIPTION
### Description

This PR addresses issue #12
I will minify/compile the js once the PR is approved

---
- There should be possibility to manually open the modal with the help of an **accessable service object** returned by initiating `animatedModal`
- Allow to completely override the predefined event handler if necessary by setting an override flag
### Example:

**Example 1**

``` js
var service = $("#demo01").animatedModal();
service.open(); // Execute it manually
```

**Example 2**

``` js
var service = $("#demo01").animatedModal({
    // do not allow at all for the internal handler of animatedModal to be executed 
    override: true
});
service.open(); // Execute it manually
```
