### PR TITLE
remove from clickable DOM after closing

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -109,7 +109,7 @@
         });
 
         function afterClose () {       
-            id.css({'z-index':settings.zIndexOut});
+            id.css({'z-index':settings.zIndexOut, display: 'none'});
             settings.afterClose(); //afterClose
         }
 


### PR DESCRIPTION
After closing, the modal stays clickable, sometimes preventing clicks to the underlying dom. When Display is set to none, this does not happen.
