### PR TITLE
Second event fix

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -108,8 +108,9 @@
 
         });
 
-        function afterClose () {       
-            id.css({'z-index':settings.zIndexOut, display: 'none'});
+        function afterClose () {
+            id.off('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend');
+            id.css({'z-index':settings.zIndexOut});
             settings.afterClose(); //afterClose
         }
 

--- a/animatedModal.js
+++ b/animatedModal.js
@@ -109,7 +109,7 @@
         });
 
         function afterClose () {       
-            id.css({'z-index':settings.zIndexOut});
+            id.css({'z-index':settings.zIndexOut, display: 'none'});
             settings.afterClose(); //afterClose
         }
 


### PR DESCRIPTION
the "close" event sometimes fires again when recreating the modal. fixed with explicitely calling "off"
