### PR TITLE
Use modal href as default modalTarget

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -13,7 +13,7 @@
         
         //Defaults
         var settings = $.extend({
-            modalTarget:'animatedModal', 
+            modalTarget: modal.attr('href').replace('#',''), 
             position:'fixed', 
             width:'100%', 
             height:'100%', 


### PR DESCRIPTION
This will make the modal to be able to open specific modal based on its target, without having to manually set modalTarget option.

(This PR doesn't update the minified script)
