### PR TITLE
No need to validate href == idConc.

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -72,19 +72,17 @@
         modal.click(function(event) {       
             event.preventDefault();
             $('body, html').css({'overflow':'hidden'});
-            if (href == idConc) {
-                if (id.hasClass(settings.modalTarget+'-off')) {
-                    id.removeClass(settings.animatedOut);
-                    id.removeClass(settings.modalTarget+'-off');
-                    id.addClass(settings.modalTarget+'-on');
-                } 
+            if (id.hasClass(settings.modalTarget+'-off')) {
+                id.removeClass(settings.animatedOut);
+                id.removeClass(settings.modalTarget+'-off');
+                id.addClass(settings.modalTarget+'-on');
+            } 
 
-                 if (id.hasClass(settings.modalTarget+'-on')) {
-                    settings.beforeOpen();
-                    id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
-                    id.addClass(settings.animatedIn);  
-                    id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
-                };  
+            if (id.hasClass(settings.modalTarget+'-on')) {
+                settings.beforeOpen();
+                id.css({'opacity':settings.opacityIn,'z-index':settings.zIndexIn});
+                id.addClass(settings.animatedIn);  
+                id.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', afterOpen);
             } 
         });
 


### PR DESCRIPTION
I think removing this check would be good as it will allow <button> or <input> elements to also open up the popup. This check restricts the usage to <a> elements as it needs a 'href' attribute.

Also, as the developer would have already specified the modal with the 'modalTarget' option, why do we need a cross-check again with the href element? I do not see any particular use for it.

Please let me know if I am missing out on anything particularly important related to the check.